### PR TITLE
Add llms.txt support via starlight-llms-txt plugin

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import starlightLlmsTxt from 'starlight-llms-txt';
 import tailwind from "@astrojs/tailwind";
 import partytown from "@astrojs/partytown";
 import vtbot from "astro-vtbot";
@@ -25,6 +26,7 @@ export default defineConfig({
     social: {
       github: 'https://github.com/fuww/developer.fashionunited.com'
     },
+    plugins: [starlightLlmsTxt()],
     head: [{
       tag: "script",
       attrs: {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-dom": "^18.3.1",
     "sharp": "^0.32.6",
     "simplex-noise": "^4.0.3",
+    "starlight-llms-txt": "^0.2.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "^3.4.6",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
Implements #73 by adding the starlight-llms-txt plugin to provide llms.txt endpoint

## Changes
- Added starlight-llms-txt dependency
- Configured the plugin in Astro config

## Testing
After merging, the llms.txt endpoint will be available at `/llms.txt`

Generated with [Claude Code](https://claude.ai/code)