### PR TITLE
Add dashboard documentation for HR managers

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -41,54 +41,79 @@ export default defineConfig({
         defer: true
       }
     }],
-    sidebar: [{
-      label: 'Docs',
-      items: [
-      // Each item here is one entry in the navigation menu.
+    sidebar: [
+      {
+        label: 'Getting Started',
+        items: [
+          { label: 'Introduction', link: '/docs/introduction/' },
+          { label: 'Logging In', link: '/docs/getting-started/login/' },
+          { label: 'Dashboard Overview', link: '/docs/getting-started/dashboard-overview/' },
+        ],
+      },
+      {
+        label: 'Jobs',
+        items: [
+          { label: 'Posting a Job', link: '/docs/dashboard-jobs/posting-a-job/' },
+          { label: 'Managing Applications', link: '/docs/dashboard-jobs/managing-applications/' },
+          { label: 'Job Analytics', link: '/docs/dashboard-jobs/job-analytics/' },
+        ],
+      },
+      {
+        label: 'Company Profile',
+        items: [
+          { label: 'Editing Your Profile', link: '/docs/company-profile/editing-your-profile/' },
+        ],
+      },
+      {
+        label: 'Credits & Billing',
+        items: [
+          { label: 'Credits and Billing', link: '/docs/billing/credits-and-billing/' },
+        ],
+      },
       {
         label: 'Advertising',
-        link: '/docs/advertising/'
-      }, {
-        label: 'FashionUnited for Websites - Embedding Jobs and News',
-        link: '/docs/fashionunited-for-websites/'
-      }, {
-        label: 'Header',
-        link: '/docs/header/'
-      }, {
-        label: 'Jobs',
-        link: '/docs/jobs/'
-      }, {
-        label: 'Logo',
-        link: '/docs/logo/'
-      }, {
-        label: 'System Requirements and Browsers',
-        link: '/docs/system-requirements-and-browsers/'
-      }]
-    }, {
-      label: 'Marketplace',
-      autogenerate: {
-        directory: 'docs/marketplace'
-      }
-    }, {
-      label: 'Editorial',
-      items: [{
-        label: 'Editorial Cheat Sheet',
-        link: '/docs/editorial-cheat-sheet/'
-      }, {
-        label: 'Editorial Style Guide',
-        link: '/docs/editorial-style-guide/'
-      }]
-    }, {
-      label: 'This site',
-      items: [{
-        label: 'Style Guide',
-        link: '/docs/style-guide/'
-      }]
-    }
-    // {
-    // 	label: 'Posts',
-    // 	autogenerate: { directory: 'posts' },
-    // },
+        items: [
+          { label: 'Advertising', link: '/docs/advertising/' },
+        ],
+      },
+      {
+        label: 'Editorial',
+        items: [
+          { label: 'Editorial Cheat Sheet', link: '/docs/editorial-cheat-sheet/' },
+          { label: 'Editorial Style Guide', link: '/docs/editorial-style-guide/' },
+        ],
+      },
+      {
+        label: 'Integration',
+        items: [
+          { label: 'FashionUnited for Websites', link: '/docs/fashionunited-for-websites/' },
+          { label: 'Jobs Feed (JSON/XML)', link: '/docs/jobs/' },
+        ],
+      },
+      {
+        label: 'Brand Assets',
+        items: [
+          { label: 'Header Image Requirements', link: '/docs/header/' },
+          { label: 'Logo', link: '/docs/logo/' },
+        ],
+      },
+      {
+        label: 'Marketplace',
+        autogenerate: { directory: 'docs/marketplace' },
+      },
+      {
+        label: 'Reference',
+        items: [
+          { label: 'System Requirements and Browsers', link: '/docs/system-requirements-and-browsers/' },
+          { label: 'Style Guide', link: '/docs/style-guide/' },
+        ],
+      },
+      {
+        label: 'Help',
+        items: [
+          { label: 'FAQ', link: '/docs/faq/' },
+        ],
+      },
     ]
   }), tailwind({
     // Disable the default base styles:

--- a/src/content/docs/docs/billing/credits-and-billing/index.md
+++ b/src/content/docs/docs/billing/credits-and-billing/index.md
@@ -1,0 +1,70 @@
+---
+title: Credits and Billing
+description: "How credits work, purchasing bundles, and managing billing on FashionUnited."
+---
+
+This section explains how credits work, how to purchase job posting bundles, and how to manage your billing on FashionUnited.
+
+## Understanding credits
+
+Credits are the currency used for publishing jobs on FashionUnited. A credit is consumed each time you publish or repost a job.
+
+| Action                | Credits consumed |
+|-----------------------|------------------|
+| **Publish a new job** | 1 credit         |
+| **Repost a job**      | 1 credit         |
+
+Credits are linked to your billing account, which is tied to one or more company profiles.
+
+## Checking your credit balance
+
+Navigate to **Jobs > Credits** in the sidebar to view your current credit balance, including available and reserved credits.
+
+[screenshot: Credits page showing available credit balance and usage summary]
+
+Administrators can view detailed credit usage and expiration dates under **Jobs > Used & Expiring Credits**. This helps you plan purchases before credits expire.
+
+[screenshot: Used and expiring credits view showing credit usage history and upcoming expirations]
+
+## Purchasing credits
+
+### Browsing bundles in the Shop
+
+Navigate to **Shop** in the sidebar to browse available job posting bundles. Bundles offer credits in packages at different price points.
+
+[screenshot: Shop page showing available bundles with prices and credit amounts]
+
+### Completing a purchase
+
+1. Select a bundle that fits your hiring needs.
+2. Click **Proceed to checkout**.
+3. Complete payment.
+4. Credits are added to your account immediately after payment is confirmed.
+
+[screenshot: Checkout flow showing bundle selection and payment step]
+
+### Viewing your orders
+
+After purchasing, view your order history and status under **Jobs > Orders** (requires admin access).
+
+[screenshot: Orders list showing recent purchases with status and amounts]
+
+Each order has a status indicating where it is in the fulfillment process. Click an order to see its details or complete any pending steps.
+
+## Managing billing accounts
+
+Your billing account determines which company profiles can use the credits you purchase. If your organization has multiple profiles, credits may be shared or allocated separately depending on how accounts are configured.
+
+Contact your account administrator or FashionUnited support if you need to change your billing account setup.
+
+## Tips
+
+- **Monitor expiration dates** — Credits may have expiration dates depending on the bundle. Check the Used & Expiring Credits page regularly.
+- **Plan purchases ahead** — Purchase bundles before you need them so jobs can be published without delay.
+- **Match bundles to hiring volume** — Larger bundles typically offer better per-credit pricing.
+
+## Next steps
+
+- [Post a job](/docs/dashboard-jobs/posting-a-job/) using your available credits
+- [Track job performance](/docs/dashboard-jobs/job-analytics/) to see the return on your investment
+- [Edit your company profile](/docs/company-profile/editing-your-profile/) to attract more candidates

--- a/src/content/docs/docs/company-profile/editing-your-profile/index.md
+++ b/src/content/docs/docs/company-profile/editing-your-profile/index.md
@@ -1,0 +1,116 @@
+---
+title: Editing Your Profile
+description: "How to edit your company profile, logo, header images, and description on FashionUnited."
+---
+
+This section explains how to edit your company profile on FashionUnited. Your company profile — also called your Branding Page — is your employer presence on the FashionUnited career site. It appears alongside every job you post and on a dedicated company page that candidates can visit directly.
+
+## Why your company profile matters
+
+A complete and well-branded profile:
+
+- Builds trust with candidates viewing your job postings
+- Showcases your brand identity with images and descriptions
+- Helps your company stand out in a competitive hiring market
+
+## Accessing the profile editor
+
+Navigate to the company profile edit page from your dashboard. If you manage multiple company profiles, select the one you want to edit.
+
+> **Note:** You need edit permissions on a company profile to access the editor. If you cannot access it, contact your account administrator.
+
+[screenshot: Navigation to the company profile editor]
+
+## Editing the company logo
+
+Your company logo appears on all job postings and your company profile page.
+
+To upload a new logo:
+
+1. Click the logo area or the upload button.
+2. Select an image file from your computer.
+3. Adjust the crop if needed.
+4. Click **Save**.
+
+[screenshot: Logo upload area with current logo and upload button]
+
+For logo specifications, see [Logo requirements](/docs/logo/).
+
+## Editing header images
+
+Header images appear at the top of your company profile page and create the first visual impression for candidates.
+
+### Desktop header image
+
+Upload a wide-format image displayed on desktop browsers.
+
+1. Click the desktop header image area.
+2. Select an image file.
+3. Click **Save**.
+
+[screenshot: Desktop header image upload area]
+
+### Mobile header image
+
+Upload a taller-format image optimized for mobile devices.
+
+1. Click the mobile header image area.
+2. Select an image file.
+3. Click **Save**.
+
+[screenshot: Mobile header image upload area]
+
+For image dimensions and format requirements, see [Header image requirements](/docs/header/).
+
+## Editing the company description
+
+Write a compelling company description that tells candidates who you are, what you do, and why they should want to work for you. The editor supports rich text formatting.
+
+Tips for an effective description:
+
+- Start with a brief overview of your company
+- Highlight what makes your workplace unique
+- Mention your industry focus and market position
+- Keep it concise — candidates scan, they do not read every word
+
+[screenshot: Company description editor with rich text toolbar]
+
+## Managing collection images
+
+Collection images showcase your products, workplace, or brand identity on the company profile page. These are optional but add visual appeal.
+
+### Adding collection images
+
+1. Navigate to the collection images section.
+2. Click **Add image**.
+3. Select and upload the image.
+4. Drag images to reorder them if needed.
+
+### Removing collection images
+
+1. Hover over the image you want to remove.
+2. Click the delete button.
+3. Confirm the removal.
+
+[screenshot: Collection images grid with add and remove controls]
+
+## Saving your changes
+
+After making edits, click **Save**. Your updates are reflected on the public FashionUnited site immediately.
+
+[screenshot: Save button and success confirmation]
+
+## How your profile appears to candidates
+
+Your company profile is visible in two places:
+
+- **On job postings** — Your logo and company name appear alongside every job you post under this profile
+- **On your company page** — A dedicated page showing your logo, header images, description, collection images, and all active job postings
+
+[screenshot: Public-facing company profile page as seen by candidates]
+
+## Next steps
+
+- [Post a job](/docs/dashboard-jobs/posting-a-job/) under your updated company profile
+- [Review job analytics](/docs/dashboard-jobs/job-analytics/) to see how your profile affects candidate engagement
+- Check [Logo](/docs/logo/) and [Header image](/docs/header/) requirements for image specifications

--- a/src/content/docs/docs/dashboard-jobs/job-analytics/index.md
+++ b/src/content/docs/docs/dashboard-jobs/job-analytics/index.md
@@ -1,0 +1,109 @@
+---
+title: Job Analytics
+description: "Understanding and using job performance data in the FashionUnited Dashboard."
+---
+
+This section explains how to understand and use the job performance data available in the FashionUnited Dashboard.
+
+## Dashboard home statistics
+
+The Dashboard Home page provides a high-level overview of your job posting performance. See [Dashboard Overview](/docs/getting-started/dashboard-overview/) for a full tour of this page.
+
+[screenshot: Dashboard home with statistics widgets highlighted]
+
+## Key metrics explained
+
+### Active jobs
+
+The number of job postings currently published and visible to candidates on FashionUnited.
+
+### Page views
+
+The total number of times your job postings have been viewed by candidates. This counts each visit to a job detail page.
+
+### Apply button clicks
+
+The number of times candidates clicked the "Apply" button on your job postings. A high click count relative to page views indicates your job descriptions are compelling.
+
+### Applicants
+
+The total number of completed applications received across all your job postings. Compare this to apply button clicks to understand how many candidates complete the application after clicking.
+
+### Reposts
+
+The number of times your jobs have been reposted (re-published after expiration or unpublishing). Useful for tracking how often roles are being recycled.
+
+### Job publications
+
+The total number of job publications, including first-time publications and reposts.
+
+## Monthly trend charts
+
+The dashboard home shows 12-month trend charts for each of the key metrics above. These charts help you:
+
+- **Spot seasonal patterns** — Identify which months see more candidate activity
+- **Measure campaign impact** — See whether changes to your job postings affect views or applications
+- **Track growth** — Monitor whether your recruiting reach is growing over time
+
+[screenshot: Monthly trend charts showing applicants, views, and clicks over 12 months]
+
+## Per-job statistics in the Jobs Table
+
+The Jobs Table (**Jobs > Jobs Table**) shows performance metrics for each individual job posting:
+
+| Column                  | What it shows                                     |
+|-------------------------|---------------------------------------------------|
+| **Views**               | Number of times this specific job was viewed      |
+| **Apply Button Clicks** | Number of apply button clicks for this job        |
+| **Applicants**          | Number of applicants for this job                 |
+
+Sort and filter the table to identify your best and worst performing postings.
+
+[screenshot: Jobs Table with views, apply button clicks, and applicants columns visible]
+
+### Comparing jobs
+
+Sort the Jobs Table by views, apply button clicks, or applicants to quickly see which jobs attract the most attention. This can help you:
+
+- Identify which job titles and descriptions resonate with candidates
+- Understand which locales generate the most interest
+- Decide which jobs to repost or highlight
+
+## Understanding the numbers
+
+### What affects page views?
+
+- The number of locales the job is published in
+- Whether the job is highlighted (promoted)
+- How recently the job was published (newer jobs appear higher in search results)
+- The attractiveness of the job title
+
+### What affects apply button clicks?
+
+- The quality and clarity of the job description
+- Salary and benefits information
+- Company reputation and profile completeness
+- Location desirability
+
+### What affects applicant count?
+
+- The simplicity of the application process (simpler forms get more completions)
+- Whether the apply button links to FashionUnited's built-in application form or an external URL
+
+## Role-based visibility
+
+Not all statistics are visible to every user. What you see depends on your account roles:
+
+| Role             | Statistics visible                            |
+|------------------|-----------------------------------------------|
+| **Job Statistics** | Active jobs, page views, apply button clicks  |
+| **Applicants**     | Applicant count and monthly applicant chart   |
+| **Transactions**   | Reposts, job publications, and monthly charts |
+
+If you are missing expected statistics, check with your account administrator about your role assignments.
+
+## Next steps
+
+- [Post a new job](/docs/dashboard-jobs/posting-a-job/) to grow your reach
+- [Manage your applicants](/docs/dashboard-jobs/managing-applications/) to keep your pipeline moving
+- [Edit your company profile](/docs/company-profile/editing-your-profile/) to improve your employer brand

--- a/src/content/docs/docs/dashboard-jobs/managing-applications/index.md
+++ b/src/content/docs/docs/dashboard-jobs/managing-applications/index.md
@@ -1,0 +1,115 @@
+---
+title: Managing Applications
+description: "How to review, manage, and communicate with applicants through the FashionUnited Dashboard."
+---
+
+This section explains how to review, manage, and communicate with applicants who apply to your job postings through FashionUnited.
+
+## Accessing the applicants list
+
+Navigate to **Jobs > Applicants** in the sidebar to view all applicants across your job postings.
+
+[screenshot: Sidebar with "Applicants" highlighted under Jobs section]
+
+## Applicants list overview
+
+The applicants list shows all applications for jobs linked to your company profiles. Each entry displays key information at a glance, including the applicant's name, the job they applied for, their current status, and the application date.
+
+[screenshot: Applicants list showing multiple applicants with status, job title, and date columns]
+
+## Filtering applicants
+
+Use the filters at the top of the list to narrow down applicants.
+
+### Filter by company profile
+
+If you manage multiple company profiles, filter to see applicants for a specific company only.
+
+### Filter by applicant status
+
+Filter by workflow status to focus on applicants at a particular stage — for example, show only "New" applicants or only "Reviewed" ones.
+
+### Filter by job
+
+View applicants for a specific job posting.
+
+### Filter by date range
+
+Narrow the list to applicants who applied within a specific time period.
+
+[screenshot: Filter bar showing company profile, status, and date range filters]
+
+## Reviewing an applicant
+
+Click an applicant's name to open their full application.
+
+### Application details
+
+The applicant detail view shows:
+
+- **Personal information** — Name and contact details
+- **Motivation / cover message** — The applicant's message or cover letter text
+- **Application date** — When the application was submitted
+
+[screenshot: Applicant detail view showing personal info and motivation text]
+
+### Viewing documents
+
+If the applicant uploaded documents, you can access them from the detail view:
+
+- **CV / Resume** — The applicant's curriculum vitae
+- **Cover letter** — A formal cover letter document (if uploaded separately)
+- **Extra documents** — Any additional files the applicant attached
+
+Document access requires the appropriate permission on your account.
+
+[screenshot: Document section showing CV, cover letter, and extra documents with download links]
+
+## Changing applicant status
+
+Move applicants through your hiring workflow by updating their status. The available statuses represent stages in the review process — for example: New, Reviewed, Shortlisted, Rejected, Hired.
+
+To change a status:
+
+1. Open the applicant detail view.
+2. Select the new status from the status dropdown.
+3. The change saves automatically.
+
+[screenshot: Status dropdown showing available workflow statuses]
+
+## Sending a message to an applicant
+
+You can message applicants directly from the dashboard:
+
+1. Open the applicant detail view.
+2. Click **Send message**.
+3. Select a message reason from the template options (e.g., interview invitation, rejection, request for more information).
+4. Write or customize your message.
+5. Click **Send**.
+
+Message reasons help categorize your communications and keep your outreach consistent.
+
+> **Note:** Messaging requires the "Send message to applicant" permission on your account. If you do not see this option, contact your account administrator.
+
+[screenshot: Send message dialog with reason template selection and message text area]
+
+## Sharing an applicant link
+
+To share a specific applicant with a colleague:
+
+1. Open the applicant detail view.
+2. Click **Copy link** to copy a direct URL to this applicant.
+3. Share the link. The recipient needs dashboard access and appropriate permissions to view the applicant.
+
+## Tips for efficient applicant management
+
+- **Review regularly** — Check for new applicants daily to respond promptly
+- **Keep statuses current** — Update statuses so your team knows where each applicant stands
+- **Use filters** — When managing multiple jobs, filter by job or status to stay organized
+- **Use message templates** — Reason templates ensure consistent communication with applicants
+
+## Next steps
+
+- [Track overall job performance](/docs/dashboard-jobs/job-analytics/)
+- [Post another job](/docs/dashboard-jobs/posting-a-job/)
+- [Edit your company profile](/docs/company-profile/editing-your-profile/)

--- a/src/content/docs/docs/dashboard-jobs/posting-a-job/index.md
+++ b/src/content/docs/docs/dashboard-jobs/posting-a-job/index.md
@@ -1,0 +1,160 @@
+---
+title: Posting a Job
+description: "How to create and publish a job posting on FashionUnited through the dashboard."
+---
+
+This section walks you through creating and publishing a job posting on FashionUnited.
+
+## Before you start
+
+To post a job, you need:
+
+- A FashionUnited Dashboard account with job posting permissions
+- At least one company profile linked to your account
+- Available credits in your account (a credit is consumed when a job is published)
+
+If you do not have credits, visit the [Shop](/docs/billing/credits-and-billing/) to purchase a bundle.
+
+## Starting a new job posting
+
+Navigate to **Jobs > Post a Job** in the sidebar to open the job form.
+
+[screenshot: Sidebar with "Post a Job" highlighted]
+
+## Selecting a company profile
+
+If your account is linked to multiple company profiles, select which company this job is for. The selected profile determines the company name, logo, and branding shown on the published job.
+
+[screenshot: Company profile selection dropdown at the top of the job form]
+
+## Using a template (optional)
+
+If your organization has saved job templates, select one to pre-fill the form. Templates save time when posting similar roles repeatedly.
+
+[screenshot: Template selection dropdown with available templates listed]
+
+Templates are managed under **Jobs > Templates** (requires admin access).
+
+## Selecting a billing account
+
+If your account is linked to multiple billing accounts, select the account to charge for this posting. The selected account must have available credits. For more information, see [Credits & Billing](/docs/billing/credits-and-billing/).
+
+[screenshot: Account selection dropdown showing available billing accounts]
+
+## Filling in the job form
+
+### Job title
+
+Enter a clear, descriptive job title. This is the main heading candidates will see.
+
+[screenshot: Job title field]
+
+### Job description
+
+Write or paste the full job description. The editor supports rich text formatting.
+
+**AI-assisted description generation:** The job form includes an AI tool that can generate or improve your job description based on the title and details you have entered. Click the AI button next to the description field to use it.
+
+[screenshot: Job description editor with the AI generation button highlighted]
+
+### Location
+
+Specify where the job is based:
+
+- **Country** — Required. Select from the dropdown.
+- **City** — The city where the role is located.
+- **Address and building** — Optional. Useful for on-site roles.
+- **Region** — The broader region or state.
+- **Geolocation** — The form can automatically validate and geocode the address you enter.
+
+[screenshot: Location fields showing country, city, and address inputs]
+
+### Categories
+
+Select one or more job categories that best describe the role. Categories help candidates find your job through search and filters.
+
+Available categories include: Design & Creative, Buying, Marketing, Retail, E-commerce, and more.
+
+[screenshot: Category selection with checkboxes]
+
+### Locales
+
+Locales are the country/language combinations where your job will be published. FashionUnited supports 50+ locales across all continents. Each locale makes the job visible on that country's FashionUnited career page.
+
+Select all locales that match your target candidates. For example, select `en-US` for the United States and `de-DE` for Germany.
+
+[screenshot: Locale selection showing available country/language options]
+
+### Posting type
+
+Choose the posting type that matches your needs (e.g., standard or premium).
+
+### Image upload
+
+Optionally upload a company image or logo to accompany the job posting. You can also upload images separately via **Jobs > Upload Image**.
+
+[screenshot: Image upload area on the job form]
+
+## Previewing your job
+
+Before submitting, click **Preview** to see how the job will appear to candidates on the FashionUnited career site.
+
+[screenshot: Job preview showing the published appearance of the job]
+
+## Submitting the job
+
+After reviewing the preview, click **Submit** to publish the job. Depending on your role:
+
+- **Full publishing rights** — The job is published immediately.
+- **Approval required** — The job is submitted for review by an administrator before publishing.
+- **Restricted rights** — The form may include a captcha step before submission.
+
+A credit is consumed when the job is published.
+
+[screenshot: Submit button and confirmation message]
+
+## After posting
+
+Once your job is published:
+
+- It appears on the FashionUnited career site in the selected locales
+- You can track its performance in [Job Analytics](/docs/dashboard-jobs/job-analytics/)
+- Applicants will appear in [Managing Applications](/docs/dashboard-jobs/managing-applications/)
+- You can manage the job from the Jobs Table
+
+## Managing jobs in the Jobs Table
+
+The Jobs Table (**Jobs > Jobs Table**) is where you manage all your job postings.
+
+[screenshot: Jobs Table showing a list of postings with status, views, and actions columns]
+
+### Filtering and sorting
+
+- Filter by status: Published, Unpublished, Expired, or Draft
+- Filter by company, locale, date range, or posting type
+- Sort by any column: title, status, views, apply clicks, dates, and more
+
+[screenshot: Jobs Table with filters applied showing a filtered list of jobs]
+
+### Job actions
+
+For each job in the table, you can:
+
+- **Edit** — Open the job form to modify details
+- **Publish** — Make a draft or unpublished job visible
+- **Unpublish** — Remove a job from public view (it stays in your Jobs Table)
+- **Repost** — Re-publish an expired job (consumes a credit)
+- **Duplicate** — Create a copy of a job to use as the basis for a new posting
+- **Highlight** — Promote a job with enhanced visibility for a set period (admin feature)
+
+[screenshot: Job actions dropdown menu on a job row in the table]
+
+### Viewing job versions
+
+You can view the version history of a job to see what changes were made over time.
+
+## Next steps
+
+- [Manage applicants who apply to your jobs](/docs/dashboard-jobs/managing-applications/)
+- [Track how your jobs are performing](/docs/dashboard-jobs/job-analytics/)
+- [Edit your company profile](/docs/company-profile/editing-your-profile/)

--- a/src/content/docs/docs/faq/index.md
+++ b/src/content/docs/docs/faq/index.md
@@ -1,0 +1,135 @@
+---
+title: FAQ
+description: "Frequently asked questions about using the FashionUnited Dashboard."
+---
+
+Frequently asked questions about using the FashionUnited Dashboard.
+
+## Account & Login
+
+### How do I create a FashionUnited Dashboard account?
+
+You can register at `dashboard.fashionunited.com` using your email address, or sign up with Google or LinkedIn. See [Logging In](/docs/getting-started/login/) for step-by-step instructions.
+
+### I forgot my password. How do I reset it?
+
+Go to the login page and click **Forgot password?** to request a reset email. See [Resetting your password](/docs/getting-started/login/#resetting-your-password) for details.
+
+### Why can I not see certain features in the dashboard?
+
+The dashboard is role-based. Features visible to you depend on the roles assigned to your account. If you need access to a feature, contact your account administrator or FashionUnited support. See [Understanding roles and permissions](/docs/getting-started/dashboard-overview/#understanding-roles-and-permissions) for more.
+
+### Can I link my Google or LinkedIn account after registering with email?
+
+Social login is set up during registration. Contact FashionUnited support if you need to change your login method.
+
+## Jobs
+
+### How do I post a new job?
+
+Navigate to **Jobs > Post a Job** in the sidebar and fill in the job form. See [Posting a Job](/docs/dashboard-jobs/posting-a-job/) for a complete walkthrough.
+
+### What are locales, and how many should I select?
+
+Locales are country/language combinations that determine where your job appears on FashionUnited. For example, selecting `en-US` publishes the job on the US English career page. Select all locales relevant to your target candidates. FashionUnited supports 50+ locales.
+
+### What is the difference between unpublishing and deleting a job?
+
+**Unpublishing** removes the job from public view but keeps it in your Jobs Table. You can re-publish it later. Jobs cannot be permanently deleted through the dashboard — they can only be unpublished or allowed to expire.
+
+### How do I repost an expired job?
+
+Open the Jobs Table, find the expired job, and select **Repost** from the job actions menu. Reposting consumes a credit. See [Job actions](/docs/dashboard-jobs/posting-a-job/#job-actions) for details.
+
+### What are credits and how are they consumed?
+
+Credits are units of posting currency. One credit is consumed each time you publish or repost a job. You can purchase credits through the Shop. See your credits balance under **Jobs > Credits**.
+
+### Can I edit a job after it is published?
+
+Yes. Find the job in the Jobs Table and click **Edit** to open the job form with the current details pre-filled. Your changes are reflected on the live posting after saving.
+
+### What is the AI-assisted description feature?
+
+When creating a job, you can use the built-in AI tool to generate or improve your job description based on the title and other details you have entered. It is optional — you can always write descriptions manually.
+
+## Applicants
+
+### How do I see applicants for my jobs?
+
+Navigate to **Jobs > Applicants** in the sidebar. You will see all applicants across your job postings. Use filters to narrow by job, status, or date. See [Managing Applications](/docs/dashboard-jobs/managing-applications/).
+
+### Can I message an applicant directly?
+
+Yes, if your account has the "Send message to applicant" permission. Open the applicant detail view and use the message function. See [Sending a message to an applicant](/docs/dashboard-jobs/managing-applications/#sending-a-message-to-an-applicant).
+
+### How do I download an applicant's CV?
+
+Open the applicant detail view and look for the documents section. You can download the CV, cover letter, and any extra documents from there. Document access requires the appropriate account permission.
+
+### What do the applicant statuses mean?
+
+Statuses represent stages in your hiring workflow — for example: New, Reviewed, Shortlisted, Rejected, Hired. You can change an applicant's status from the detail view. See [Changing applicant status](/docs/dashboard-jobs/managing-applications/#changing-applicant-status).
+
+## Credits & Billing
+
+### How do I purchase credits?
+
+Navigate to **Shop** in the sidebar to browse available bundles. Select a bundle, complete the checkout, and credits are added to your account. See [Credits & Billing](/docs/billing/credits-and-billing/) for details.
+
+### How do I check my credit balance?
+
+Go to **Jobs > Credits** in the sidebar to see your available credits. Administrators can also view expiring credits under **Jobs > Used & Expiring Credits**.
+
+### Do credits expire?
+
+Credits may have expiration dates depending on the bundle purchased. Check the Used & Expiring Credits page for details on upcoming expirations.
+
+## Company Profile
+
+### How do I update my company logo or images?
+
+Navigate to the company profile editor from your dashboard. You can upload a new logo, desktop and mobile header images, and collection images. See [Editing Your Profile](/docs/company-profile/editing-your-profile/).
+
+### What image formats and sizes are recommended?
+
+See [Logo requirements](/docs/logo/) and [Header image requirements](/docs/header/) for detailed specifications.
+
+## Statistics & Analytics
+
+### What statistics are available on the dashboard?
+
+The dashboard shows active jobs, page views, apply button clicks, applicant counts, reposts, and job publications — both as totals and as 12-month trend charts. See [Job Analytics](/docs/dashboard-jobs/job-analytics/).
+
+### Why do I not see all statistics?
+
+Statistics visibility is role-based. You may only see a subset depending on your account permissions. See [Role-based visibility](/docs/dashboard-jobs/job-analytics/#role-based-visibility).
+
+## Technical
+
+### What browsers are supported?
+
+See [System Requirements and Browsers](/docs/system-requirements-and-browsers/) for supported browsers and versions.
+
+### Who do I contact for support?
+
+For technical issues or account questions, use the **Contact** link in the dashboard sidebar or reach out to your FashionUnited account manager.
+
+## Glossary
+
+| Term                    | Definition                                                                               |
+|-------------------------|------------------------------------------------------------------------------------------|
+| **Applicant**           | A person who applied for a job through FashionUnited                                     |
+| **Applicant Status**    | The workflow stage of an application (e.g., New, Reviewed, Hired)                        |
+| **Bundle**              | A package of credits available for purchase in the Shop                                  |
+| **Credit**              | A unit consumed when publishing or reposting a job                                       |
+| **Dashboard**           | The authenticated admin area at `dashboard.fashionunited.com`                            |
+| **Highlight**           | Enhanced visibility promotion for a job posting over a set period                        |
+| **Job Posting**         | A published job advertisement on FashionUnited                                           |
+| **Jobs Table**          | The dashboard view listing all your job postings with filters, sorting, and actions      |
+| **Locale**              | A country/language combination where a job appears (e.g., en-US, de-DE)                 |
+| **Profile**             | A company's employer branding page on FashionUnited (also called Branding Page)          |
+| **Repost**              | Re-publishing an expired or unpublished job (consumes a credit)                          |
+| **Scoped Role**         | A permission limited to specific company profiles                                        |
+| **Template**            | A predefined job structure used to pre-fill new job forms                                |
+| **Universal Form**      | FashionUnited's built-in application form used by candidates to apply for jobs           |

--- a/src/content/docs/docs/getting-started/dashboard-overview/index.md
+++ b/src/content/docs/docs/getting-started/dashboard-overview/index.md
@@ -1,0 +1,91 @@
+---
+title: Dashboard Overview
+description: "A tour of the FashionUnited Dashboard interface, sidebar navigation, and roles."
+---
+
+This section gives you a tour of the FashionUnited Dashboard interface so you can quickly find the features you need.
+
+## The dashboard home page
+
+When you log in, you land on the Dashboard Home page. This page provides an at-a-glance summary of your job posting activity.
+
+[screenshot: Dashboard home page with statistics widgets and monthly charts]
+
+### Statistics widgets
+
+The home page displays key metrics as summary cards at the top:
+
+- **Active Jobs** — Number of currently published job postings
+- **Page Views** — Total views across all your job postings
+- **Apply Button Clicks** — Total clicks on the "Apply" button
+- **Applicants** — Total number of applicants received
+- **Reposts** — Number of job reposts
+- **Job Publications** — Number of job publications
+
+Which statistics you see depends on your account permissions. Not all widgets are visible to every user.
+
+[screenshot: Close-up of the statistics widgets showing active jobs, views, and clicks]
+
+### Monthly trend charts
+
+Below the summary cards, the dashboard shows 12-month trend charts for key metrics:
+
+- Applicants per month
+- Job publications per month
+- Reposts per month
+- Apply button clicks per month
+- Page views per month
+
+These charts help you spot trends in your recruiting activity over time.
+
+[screenshot: Monthly trend chart showing applicants over the past 12 months]
+
+## Sidebar navigation
+
+The sidebar on the left is your main navigation. It is organized into sections based on feature area. The sections visible to you depend on your account roles and permissions.
+
+### Navigation for HR managers and recruiters
+
+The most common sidebar sections for recruiters:
+
+| Section            | What you will find                                      |
+|--------------------|---------------------------------------------------------|
+| **Dashboard Home** | Statistics overview — click the FashionUnited logo to return here |
+| **Jobs**           | Post a Job, Jobs Table, Applicants, Upload Image, Credits |
+| **Shop**           | Purchase job posting bundles and credits                |
+
+[screenshot: Sidebar navigation showing Jobs section expanded with sub-items]
+
+### Additional sections
+
+Depending on your role, you may also see:
+
+- **News** — For editorial staff managing articles and content
+- **Events** — For managing fashion industry events
+- **Marketplace** — For marketplace brand management
+- **User & Account** — For account administrators
+- **Tools** — For internal staff (translation, AI tools, finance)
+
+## Understanding roles and permissions
+
+Your dashboard experience is shaped by the roles assigned to your account. There are two types:
+
+### Scoped roles
+
+Permissions tied to specific company profiles. For example, you may have permission to manage jobs and applicants for "Company A" but not "Company B."
+
+### Global roles
+
+Platform-wide permissions typically held by FashionUnited internal staff or administrators.
+
+If you cannot see a feature described in this guide, your account may not have the required role. Contact your account administrator or FashionUnited support.
+
+## Next steps
+
+Now that you know your way around the dashboard:
+
+- [Post your first job](/docs/dashboard-jobs/posting-a-job/)
+- [Review applicants](/docs/dashboard-jobs/managing-applications/)
+- [Check job performance](/docs/dashboard-jobs/job-analytics/)
+- [Edit your company profile](/docs/company-profile/editing-your-profile/)
+- [Understand credits and billing](/docs/billing/credits-and-billing/)

--- a/src/content/docs/docs/getting-started/login/index.md
+++ b/src/content/docs/docs/getting-started/login/index.md
@@ -1,0 +1,107 @@
+---
+title: Logging In
+description: "How to access the FashionUnited Dashboard, create an account, and manage your password."
+---
+
+This section covers how to access the FashionUnited Dashboard, create an account, and manage your password.
+
+## Accessing the Dashboard
+
+The FashionUnited Dashboard is available at `dashboard.fashionunited.com`. You need an account to access any dashboard features.
+
+[screenshot: The dashboard login page at dashboard.fashionunited.com]
+
+## Creating an account
+
+There are three ways to register for a FashionUnited Dashboard account.
+
+### Register with email
+
+1. Go to `dashboard.fashionunited.com/register`.
+2. Enter your first name, last name, and email address.
+3. Choose a password.
+4. Click **Register**.
+5. Check your inbox for a verification email and click the confirmation link to activate your account.
+
+[screenshot: Registration form with email, name, and password fields]
+
+### Register with Google
+
+1. On the registration page, click **Sign up with Google**.
+2. Select your Google account from the browser prompt.
+3. Grant the requested permissions.
+4. You are registered and logged in immediately.
+
+[screenshot: Google OAuth sign-in button on the registration page]
+
+### Register with LinkedIn
+
+1. On the registration page, click **Sign up with LinkedIn**.
+2. Log in to LinkedIn if prompted.
+3. Authorize FashionUnited to access your profile.
+4. You are registered and logged in immediately.
+
+[screenshot: LinkedIn OAuth sign-in button on the registration page]
+
+## Logging in
+
+### Email and password login
+
+1. Go to `dashboard.fashionunited.com`.
+2. Enter your registered email address and password.
+3. Click **Log in**.
+
+[screenshot: Login form with email and password fields]
+
+### Social login (Google / LinkedIn)
+
+If you registered with Google or LinkedIn, click the corresponding button on the login page and follow the authentication prompt. You do not need to enter a password.
+
+## Resetting your password
+
+### Requesting a password reset
+
+1. Go to the login page.
+2. Click **Forgot password?**
+3. Enter your registered email address.
+4. Click **Send reset email**.
+5. Check your inbox for the reset email.
+
+[screenshot: Password reset request form]
+
+### Setting a new password
+
+1. Open the password reset email from FashionUnited.
+2. Click the reset link in the email.
+3. Enter your new password and confirm it.
+4. Click **Save password**.
+5. You are redirected to the login page. Log in with your new password.
+
+[screenshot: New password form accessed via the reset email link]
+
+## Setting your initial password
+
+If you received an invitation link to join FashionUnited, your account is already created. To set your password:
+
+1. Click the link in your invitation email.
+2. Choose a password and confirm it.
+3. Click **Set password**.
+
+You can now log in with your email and this password.
+
+## Logging out
+
+To log out, open the user menu in the dashboard and click **Log out**. This ends your session and returns you to the login page.
+
+## Editing your user profile
+
+After logging in, you can update your personal profile information — name, contact details, and preferences — from the user profile page. Look for your name or avatar in the top navigation to access profile settings.
+
+## Troubleshooting login issues
+
+- **"Invalid credentials" error** — Double-check your email and password. Passwords are case-sensitive.
+- **Not receiving the reset email** — Check your spam or junk folder. The email is sent from FashionUnited.
+- **Social login not working** — Make sure you originally registered with that social provider.
+- **Account locked or restricted** — Contact FashionUnited support for assistance.
+
+See also: [FAQ](/docs/faq/) for more common questions and [Dashboard Overview](/docs/getting-started/dashboard-overview/) for an orientation of the dashboard after logging in.

--- a/src/content/docs/docs/introduction/index.md
+++ b/src/content/docs/docs/introduction/index.md
@@ -1,6 +1,57 @@
 ---
 title: Introduction
-author: Joost van der Laan
+description: "Welcome to the FashionUnited Dashboard documentation for HR managers, recruiters, and hiring teams."
 ---
 
-## Introduction
+Welcome to the FashionUnited Dashboard documentation. This guide helps HR managers, recruiters, and hiring teams get the most out of the FashionUnited platform for posting jobs, managing applicants, and building your employer brand in the fashion industry.
+
+## What is the FashionUnited Dashboard?
+
+The FashionUnited Dashboard is your central hub for managing job postings, reviewing applicants, tracking performance, and maintaining your company's presence on the FashionUnited career platform.
+
+Key capabilities covered in this guide:
+
+- **Post and manage job listings** across 50+ country/language combinations
+- **Review and communicate with applicants** through a built-in workflow
+- **Track job performance** with views, clicks, and applicant statistics
+- **Edit your company profile** to strengthen your employer brand
+- **Purchase and manage credits** for job postings through the Shop
+
+## Who is this guide for?
+
+This documentation is written for:
+
+- **HR managers and recruiters** who use the dashboard to post jobs and manage applicants
+- **Hiring managers** who review applicant profiles and documents
+- **Account administrators** who manage credits, billing, and company profiles
+
+If you are looking for technical integration guides (XML/JSON job feeds, marketplace API, embedding widgets), see the dedicated sections later in this guide.
+
+## How to use this guide
+
+Start with [Getting Started](/docs/getting-started/login/) if you are new to the platform. If you already have an account, jump directly to the section that matches your task:
+
+| I want to...                        | Go to                                                         |
+|-------------------------------------|---------------------------------------------------------------|
+| Log in or reset my password         | [Logging In](/docs/getting-started/login/)                      |
+| Understand the dashboard layout     | [Dashboard Overview](/docs/getting-started/dashboard-overview/) |
+| Create a new job posting            | [Posting a Job](/docs/dashboard-jobs/posting-a-job/)                      |
+| Review applicants for my jobs       | [Managing Applications](/docs/dashboard-jobs/managing-applications/)      |
+| See how my jobs are performing      | [Job Analytics](/docs/dashboard-jobs/job-analytics/)                      |
+| Update my company page              | [Editing Your Profile](/docs/company-profile/editing-your-profile/) |
+| Buy credits or manage billing       | [Credits & Billing](/docs/billing/credits-and-billing/)         |
+| Find answers to common questions    | [FAQ](/docs/faq/)                                               |
+
+## Key terminology
+
+Before diving in, here are a few terms used throughout this guide:
+
+- **Job Posting** — A published job advertisement visible on FashionUnited
+- **Locale** — A country/language combination where your job appears (e.g., en-US, de-DE)
+- **Credit** — A unit consumed when publishing or reposting a job
+- **Profile** — Your company's employer branding page on FashionUnited
+- **Applicant Status** — The workflow stage of an application (e.g., New, Reviewed, Hired)
+
+For a complete glossary, see the [FAQ](/docs/faq/#glossary).
+
+[screenshot: FashionUnited Dashboard home page showing the sidebar navigation and statistics overview]


### PR DESCRIPTION
## Summary

- Add 9 documentation pages covering the FashionUnited Dashboard for HR managers, recruiters, and hiring teams
- Restructure sidebar from flat "Docs" group into 11 semantic groups (Getting Started, Jobs, Company Profile, Credits & Billing, etc.)
- Update introduction page with comprehensive onboarding content

### New pages
- **Getting Started**: Introduction, Logging In, Dashboard Overview
- **Jobs**: Posting a Job, Managing Applications, Job Analytics
- **Company Profile**: Editing Your Profile
- **Credits & Billing**: Credits and Billing
- **Help**: FAQ with glossary

### Sidebar changes
- Flat "Docs" group split into: Getting Started, Jobs, Company Profile, Credits & Billing
- Existing pages reorganized into: Advertising, Editorial, Integration, Brand Assets
- "This site" renamed to "Reference"
- Marketplace autogenerate preserved
- New dashboard job docs use `dashboard-jobs/` path to avoid conflict with existing `jobs/` (XML/JSON feed integration)

## Test plan

- [x] `pnpm build` passes with 0 errors, 0 warnings
- [x] All 9 new pages render correctly (verified via build output)
- [x] All relative links converted to absolute Starlight paths
- [x] No duplicate H1 headings (stripped from content, generated from frontmatter)
- [ ] Verify sidebar renders correctly in dev server
- [ ] Spot-check internal links resolve in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)