### PR TITLE
Switch to beads_rust, remove Go-based beads

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,26 +21,56 @@
       forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
         pkgs = import nixpkgs { inherit system; };
       });
+
+      beadsRustVersion = "0.1.19";
+      beadsRustHashes = {
+        "x86_64-linux" = "sha256-61a0IeR+NI56GDJdIQlxeiQ3wqNneAe1gUPzAz5oTMw=";
+        "x86_64-darwin" = "sha256-98srAx9fRr7NDbzVjIs4za7KONicVgPkZEimSaZ85/w=";
+        "aarch64-darwin" = "sha256-p8cZ6+c4LUSMU1Cvz+lus6NfYYTWFilCD2Jt2G+PGSg=";
+      };
+      beadsRustTargets = {
+        "x86_64-linux" = "linux_amd64";
+        "x86_64-darwin" = "darwin_amd64";
+        "aarch64-darwin" = "darwin_arm64";
+      };
     in
     {
       # Development environment output
-      devShells = forAllSystems ({ pkgs }: {
-        default = pkgs.mkShell {
-          # The Nix packages provided in the environment
-          packages = with pkgs; [
+      devShells = nixpkgs.lib.genAttrs allSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          beads-rust = pkgs.stdenv.mkDerivation {
+            pname = "beads-rust";
+            version = beadsRustVersion;
+            src = pkgs.fetchurl {
+              url = "https://github.com/Dicklesworthstone/beads_rust/releases/download/v${beadsRustVersion}/br-v${beadsRustVersion}-${beadsRustTargets.${system}}.tar.gz";
+              hash = beadsRustHashes.${system};
+            };
+            sourceRoot = ".";
+            installPhase = ''
+              mkdir -p $out/bin
+              cp br $out/bin/
+              chmod +x $out/bin/br
+            '';
+            meta = {
+              description = "AI-supervised issue tracker (Rust rewrite)";
+              homepage = "https://github.com/Dicklesworthstone/beads_rust";
+              license = pkgs.lib.licenses.mit;
+            };
+          };
+        in {
+          default = pkgs.mkShell {
+            # The Nix packages provided in the environment
+            packages = with pkgs; [
               bun
               nixpkgs-fmt
-              go
-          ];
+              beads-rust
+            ];
 
-          shellHook = ''
-            if ! command -v bd &> /dev/null; then
-              echo "Installing beads (bd) for AI agent task tracking..."
-              go install github.com/steveyegge/beads/cmd/bd@latest
-            fi
-            echo "  Beads:       $(bd --version 2>/dev/null || echo 'run: go install github.com/steveyegge/beads/cmd/bd@latest')"
-          '';
-        };
-      });
+            shellHook = ''
+              echo "  Beads:       $(br --version)"
+            '';
+          };
+        });
     };
 }


### PR DESCRIPTION
## Summary
- Replace Go-based beads (`bd`) with Rust rewrite (`br` v0.1.19) from [beads_rust](https://github.com/Dicklesworthstone/beads_rust)
- Remove `go` dependency (only needed for old beads)
- Prebuilt binaries for x86_64-linux, x86_64-darwin, aarch64-darwin

## Test plan
- [ ] `nix develop --command br --version` returns `br 0.1.19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)