### PR TITLE
chore: replace secrets.ANTHROPIC_API_KEY with secrets.CLAUDE_CODE_OAUTH_TOKEN

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,8 @@
       "Bash(git -C /Volumes/data/git/fuww/about.fashionunited.com commit -m \"$(cat <<''EOF''\nFix pnpm version conflict in GitHub Actions\n\nRemoved explicit version numbers from pnpm/action-setup@v4 to allow\nit to automatically read the version from packageManager field in\npackage.json (10.15.0), avoiding version conflicts.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nEOF\n)\")",
       "Bash(git -C /Volumes/data/git/fuww/about.fashionunited.com push)",
       "Bash(git -C /Volumes/data/git/fuww/about.fashionunited.com add .npmrc Dockerfile)",
-      "Bash(git -C /Volumes/data/git/fuww/about.fashionunited.com commit -m \"$(cat <<''EOF''\nEnable build scripts via .npmrc configuration\n\nAdded .npmrc with enable-pre-post-scripts=true to allow Sharp and\nother dependencies to run their build scripts during installation.\nThis eliminates the need for explicit pnpm rebuild commands and\nresolves the \"Ignored build scripts\" warning.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nEOF\n)\")"
+      "Bash(git -C /Volumes/data/git/fuww/about.fashionunited.com commit -m \"$(cat <<''EOF''\nEnable build scripts via .npmrc configuration\n\nAdded .npmrc with enable-pre-post-scripts=true to allow Sharp and\nother dependencies to run their build scripts during installation.\nThis eliminates the need for explicit pnpm rebuild commands and\nresolves the \"Ignored build scripts\" warning.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nEOF\n)\")",
+      "Bash(python3:*)"
     ],
     "deny": [],
     "ask": []

--- a/.github/workflows/claude-dispatch.yml
+++ b/.github/workflows/claude-dispatch.yml
@@ -33,7 +33,7 @@ jobs:
           mode: 'remote-agent'
 
           # Optional: Specify an API key, otherwise we'll use your Claude account automatically
-          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -54,9 +54,33 @@ export default defineConfig({
       {
         label: 'Jobs',
         items: [
+          { label: 'Dashboard Access', link: '/docs/jobs/dashboard-access/' },
           { label: 'Posting a Job', link: '/docs/dashboard-jobs/posting-a-job/' },
           { label: 'Managing Applications', link: '/docs/dashboard-jobs/managing-applications/' },
           { label: 'Job Analytics', link: '/docs/dashboard-jobs/job-analytics/' },
+          { label: 'Job Layout', link: '/docs/jobs/job-layout/' },
+          { label: 'Employer Page', link: '/docs/jobs/employer-page/' },
+          { label: 'Manual Job Posting', link: '/docs/jobs/manual-posting/' },
+        ],
+      },
+      {
+        label: 'Premium Employer',
+        items: [
+          { label: 'Overview', link: '/docs/jobs/premium-employer/' },
+          { label: 'News Membership', link: '/docs/jobs/premium-employer/news-membership/' },
+          { label: 'Premium Header Image', link: '/docs/jobs/premium-employer/premium-header/' },
+          { label: 'Job Template', link: '/docs/jobs/premium-employer/job-template/' },
+          { label: 'Employer Branding Page', link: '/docs/jobs/premium-employer/employer-branding-page/' },
+        ],
+      },
+      {
+        label: 'Integration',
+        items: [
+          { label: 'Integrations Overview', link: '/docs/jobs/integrations-overview/' },
+          { label: 'Job Feed Inbound (JSON/XML)', link: '/docs/jobs/' },
+          { label: 'Job Scraper', link: '/docs/jobs/job-scraper/' },
+          { label: 'Job Feed Outbound', link: '/docs/jobs/outbound-feed/' },
+          { label: 'Job Embedder', link: '/docs/fashionunited-for-websites/' },
         ],
       },
       {
@@ -82,13 +106,6 @@ export default defineConfig({
         items: [
           { label: 'Editorial Cheat Sheet', link: '/docs/editorial-cheat-sheet/' },
           { label: 'Editorial Style Guide', link: '/docs/editorial-style-guide/' },
-        ],
-      },
-      {
-        label: 'Integration',
-        items: [
-          { label: 'FashionUnited for Websites', link: '/docs/fashionunited-for-websites/' },
-          { label: 'Jobs Feed (JSON/XML)', link: '/docs/jobs/' },
         ],
       },
       {

--- a/src/content/docs/docs/dashboard-jobs/posting-a-job/index.md
+++ b/src/content/docs/docs/dashboard-jobs/posting-a-job/index.md
@@ -158,3 +158,6 @@ You can view the version history of a job to see what changes were made over tim
 - [Manage applicants who apply to your jobs](/docs/dashboard-jobs/managing-applications/)
 - [Track how your jobs are performing](/docs/dashboard-jobs/job-analytics/)
 - [Edit your company profile](/docs/company-profile/editing-your-profile/)
+- [Job Layout](/docs/jobs/job-layout/) -- Logo and image requirements for job postings
+- [Manual Job Posting](/docs/jobs/manual-posting/) -- Submit jobs via email to Customer Service
+- [Integrations Overview](/docs/jobs/integrations-overview/) -- Automate job posting via ATS feed or scraper

--- a/src/content/docs/docs/fashionunited-for-websites/index.md
+++ b/src/content/docs/docs/fashionunited-for-websites/index.md
@@ -7,6 +7,10 @@ Fashionunited for Websites is a suite of embeddable widgets, buttons, and
 client-side scripting tools to integrate Fashionunited and display jobs on your
 website or JavaScript application, including Embedded Jobs.
 
+This is ideal for companies who do not have their own career page or do not have an ATS system. Jobs that are manually posted on FashionUnited automatically go live on your website as well. Via the Dashboard you are able to manage the jobs (publish, unpublish, repost, and edit). FashionUnited serves as "the source" -- the connection between our job board and your website.
+
+The Customer Service team can create the embed code for you ([jobs@fashionunited.com](mailto:jobs@fashionunited.com)). For an overview of all integration options, see [Integrations Overview](/docs/jobs/integrations-overview/).
+
 ## Embedded Job Accordion
 
 (Embed jobs on your site, loaded from our API)

--- a/src/content/docs/docs/getting-started/dashboard-overview/index.md
+++ b/src/content/docs/docs/getting-started/dashboard-overview/index.md
@@ -84,6 +84,7 @@ If you cannot see a feature described in this guide, your account may not have t
 
 Now that you know your way around the dashboard:
 
+- [Set up Dashboard access](/docs/jobs/dashboard-access/) if you haven't already
 - [Post your first job](/docs/dashboard-jobs/posting-a-job/)
 - [Review applicants](/docs/dashboard-jobs/managing-applications/)
 - [Check job performance](/docs/dashboard-jobs/job-analytics/)

--- a/src/content/docs/docs/header/index.md
+++ b/src/content/docs/docs/header/index.md
@@ -17,3 +17,5 @@ requirements:
 
 Higher resolution or bigger image size is always better in this case. Also, we
 can always downsize to the specified dimensions.
+
+See also: [Premium Header Image](/docs/jobs/premium-employer/premium-header/) for premium employer banner images, and [Job Layout](/docs/jobs/job-layout/) for job posting image requirements.

--- a/src/content/docs/docs/jobs/dashboard-access/index.md
+++ b/src/content/docs/docs/jobs/dashboard-access/index.md
@@ -1,0 +1,25 @@
+---
+title: Dashboard Access
+description: "How to create a FashionUnited Dashboard login to manage jobs, candidates, statistics, and credits."
+---
+
+To submit and manage your jobs, candidate data (if applicable), access statistics and credit status, you can create a login for the FashionUnited Dashboard.
+
+## Getting started
+
+1. Go to [dashboard.fashionunited.com](https://dashboard.fashionunited.com) and create an account
+2. Check your email inbox and verify your email address
+3. Contact [jobs@fashionunited.com](mailto:jobs@fashionunited.com) and ask to have your account linked to your company profile (provide the email address you are logged in with)
+4. Once your account is linked you can access and manage your data in the Dashboard
+
+## What you can do in the Dashboard
+
+Once your account is linked to a company profile, you can:
+
+- [Post and manage jobs](/docs/dashboard-jobs/posting-a-job/)
+- [Review and manage applications](/docs/dashboard-jobs/managing-applications/)
+- [View job analytics](/docs/dashboard-jobs/job-analytics/)
+- [Manage credits and billing](/docs/billing/credits-and-billing/)
+- [Edit your company profile](/docs/company-profile/editing-your-profile/)
+
+For a full tour of the Dashboard interface, see the [Dashboard Overview](/docs/getting-started/dashboard-overview/).

--- a/src/content/docs/docs/jobs/employer-page/index.md
+++ b/src/content/docs/docs/jobs/employer-page/index.md
@@ -1,0 +1,24 @@
+---
+title: Employer Page
+description: "Your company's employer page on FashionUnited -- setup, content, and how to update it."
+---
+
+Every company or brand publishing jobs on FashionUnited has their own employer page. An Employer Page is a basic page, also known as a "Work at" or "dedicated" page. It contains a preset banner image, the company or brand logo, company description, and job overview.
+
+## Initial setup
+
+We will set up the page using the logo from your first job posting and will add a company description (taken from either the job description or your own website).
+
+## Updating your employer page
+
+Logo and description can be changed by contacting [jobs@fashionunited.com](mailto:jobs@fashionunited.com). Send the link to your employer page along with the information you want updated.
+
+### What you can provide
+
+- **Logo** -- Your logo as SVG (or PNG) file. See the [Logo requirements](/docs/logo/) for specifications.
+- **Company description** -- A short description of your company (who are you)?
+- **Translations** -- When posting jobs internationally, the company description can be displayed in different languages (per country a job is published on).
+
+## Premium employer page
+
+For a fully customised employer page with additional tabs, custom banner images, and highlighted job listings, see [Employer Branding Page](/docs/jobs/premium-employer/employer-branding-page/).

--- a/src/content/docs/docs/jobs/index.md
+++ b/src/content/docs/docs/jobs/index.md
@@ -1,14 +1,14 @@
 ---
-title: "Posting jobs, feed integration via JSON or XML"
+title: "Job Feed Inbound (JSON/XML)"
 author: Joost van der Laan
 ---
-
-# Introduction
 
 FashionUnited’s feed service provides a full suite of real-time, highly
 available Jobboard transactions. This service opens the door to FashionUnited’s
 infrastructure and enables you to execute a wide variety of jobboard
 transactions empowering you to control your content at FashionUnited.
+
+To be able to set up a feed we need a so-called XML URL. You can share this with the Customer Service team via [jobs@fashionunited.com](mailto:jobs@fashionunited.com). In this link all of your jobs should be found. Sometimes the link also contains jobs of several clients. The link can also be called RSS, JSON or API link/URL.
 
 To keep things simple, we also accept existing feeds you might have created for
 other jobboards, like:
@@ -21,7 +21,27 @@ other jobboards, like:
 
 Therefore, as long as you make sure all the jobs you want posted on the
 FashionUnited platform are in your JSON or XML feed, we make sure they are shown
-on the FashionUnited platform.
+on the FashionUnited platform. Also some providers give clients the ability to share a link with us in which all jobs they have open currently are visible.
+
+The feed refreshes once per day during the week and syncs the content of the feed with what is displayed on the FashionUnited job board.
+
+For an overview of all integration options, see [Integrations Overview](/docs/jobs/integrations-overview/). To send your FashionUnited jobs to your own website instead, see [Job Feed Outbound](/docs/jobs/outbound-feed/).
+
+## Mandatory fields
+
+The following fields are required in your feed:
+
+- **Unique job ID** (`externalId`) -- unique identifier in your system
+- **Job title** (`title`) -- only the title, no location etc.
+- **Job category** (`category`) -- one of: "Design & Creative", "Internships", "Other", "Product & Supply Chain", "Retail Management & In-store", "Sales & Marketing"
+- **Teaser text** (`qualifications`) -- short description for the job list
+- **Vacancy text** (`description`) -- full job description
+- **City** (`city`) -- an address can also be sent in an `address` field
+- **Country** (`country`)
+- **Company name** (`company`)
+- **Apply URL** -- unique per job ID
+
+## Supported locales
 
 As of now we provide jobboard services for the following countries:
 

--- a/src/content/docs/docs/jobs/integrations-overview/index.md
+++ b/src/content/docs/docs/jobs/integrations-overview/index.md
@@ -1,0 +1,34 @@
+---
+title: Integrations Overview
+description: "How to connect your Applicant Tracking System (ATS) to FashionUnited for automated job posting."
+---
+
+An ATS (Applicant Tracking System) is a system which clients use to track the status of candidates who apply via their own career page. Posting positions via an ATS system gives you the ability to manage candidates that apply for positions -- including when the job is posted on FashionUnited, since we will most likely use an external application link which leads to your website and application form.
+
+Various companies provide Applicant Tracking System software. These systems give you the ability to post open positions on your own career page and on external websites such as Indeed, LinkedIn, and FashionUnited.
+
+## Checking your ATS connection
+
+When you see "FashionUnited" as an external page you can select in your ATS system, we either already have a running connection, or are able to set it up. When in doubt, reach out to [jobs@fashionunited.com](mailto:jobs@fashionunited.com) and the Customer Service team will check if there already is a connection or if we need to set it up.
+
+## Inbound integration methods (client to FashionUnited)
+
+There are two ways to get your jobs from your system onto FashionUnited automatically:
+
+| Method | Best for | Details |
+|--------|----------|---------|
+| **Job Feed** | Companies with an ATS that can produce an XML, JSON, or RSS feed | [Job Feed Inbound](/docs/jobs/) |
+| **Job Scraper** | Companies without an ATS or whose ATS charges setup fees for new channels | [Job Scraper](/docs/jobs/job-scraper/) |
+
+## Outbound integration methods (FashionUnited to client)
+
+There are two ways to display your FashionUnited-hosted jobs on your own website:
+
+| Method | Best for | Details |
+|--------|----------|---------|
+| **Job Feed Outbound** | Companies that can consume an XML feed on their end | [Job Feed Outbound](/docs/jobs/outbound-feed/) |
+| **Job Embedder** | Companies without a career page or without an ATS | [Job Embedder](/docs/fashionunited-for-websites/) |
+
+## Manual posting
+
+If you do not have an ATS or prefer to post jobs manually, see [Manual Job Posting](/docs/jobs/manual-posting/).

--- a/src/content/docs/docs/jobs/job-layout/index.md
+++ b/src/content/docs/docs/jobs/job-layout/index.md
@@ -1,0 +1,30 @@
+---
+title: Job Layout
+description: "Job posting layouts, logo and image requirements for publishing jobs on FashionUnited."
+---
+
+Jobs on FashionUnited can be published in different layouts. For your first job posting (via the Dashboard or via the Customer Service Team), you can submit your logo and an image.
+
+## Logo
+
+Your logo as SVG (or PNG) file. SVG is recommended for the best quality across all devices. See the [Logo requirements](/docs/logo/) page for detailed specifications.
+
+## Image
+
+Submit 1 image showcasing your brand. Think of showing part of your collection, the office, the team -- a motive which gives potential candidates a good first impression.
+
+### Image requirements
+
+- Landscape format
+- 970 px wide minimum
+- High resolution
+
+For header image specifications, see [Header Image Requirements](/docs/header/).
+
+## Full HTML job layout
+
+For more advanced branding options, including custom HTML styling, CSS, fonts, media embeds, and templates, see the [Job Feed Inbound](/docs/jobs/) documentation.
+
+## Premium job templates
+
+As a [Premium Employer](/docs/jobs/premium-employer/), you can receive a custom [job template](/docs/jobs/premium-employer/job-template/) with up to 3 images and a video.

--- a/src/content/docs/docs/jobs/job-scraper/index.md
+++ b/src/content/docs/docs/jobs/job-scraper/index.md
@@ -1,0 +1,29 @@
+---
+title: Job Scraper
+description: "How FashionUnited can mirror jobs from your career page using a scraper tool."
+---
+
+You might have jobs on your own website but do not have an ATS system, or your ATS provider charges a setup fee (and possibly annual fees) when you request to add FashionUnited as an option in your system.
+
+FashionUnited can build a scraper tool in this case. The scraper "copies" jobs that are currently live on your career page. Jobs that are no longer there when the scraper checks the page will go offline on our job board. A scraper basically "mirrors" the jobs on your page on our page.
+
+## Setup
+
+To set up a scraper, share the link to your career page with the Customer Service team via [jobs@fashionunited.com](mailto:jobs@fashionunited.com).
+
+## How it works
+
+- The scraper refreshes once per day during the week
+- It syncs the content of your career page with what is displayed on the FashionUnited job board
+- Jobs that are removed from your career page are automatically unpublished from FashionUnited
+
+## Limitations
+
+- Not all career pages are set up in a way that a scraper tool will work
+- If you make any changes to the structure of your website or career page, the scraper may stop working
+- Contact [jobs@fashionunited.com](mailto:jobs@fashionunited.com) if you experience any issues after making website changes
+
+## Alternatives
+
+- If you have an ATS that can produce a feed, consider using a [Job Feed](/docs/jobs/) instead for more reliable integration
+- For a full overview of integration options, see [Integrations Overview](/docs/jobs/integrations-overview/)

--- a/src/content/docs/docs/jobs/manual-posting/index.md
+++ b/src/content/docs/docs/jobs/manual-posting/index.md
@@ -1,0 +1,42 @@
+---
+title: Manual Job Posting
+description: "Two ways to manually publish jobs on FashionUnited: via the Dashboard or via Customer Service."
+---
+
+There are two different ways to manually publish jobs on FashionUnited.
+
+## Submit via Dashboard
+
+You can use the Dashboard to submit your jobs. You can either submit a new job (**Post a Job**) or duplicate an existing position from the job list. See [Posting a Job](/docs/dashboard-jobs/posting-a-job/) for a step-by-step guide.
+
+- **No product linked:** When you do not have a product linked to your account or company, the Customer Service team will handle your request and might be in touch with you in case of questions before confirming the publication of the job.
+- **Product linked:** When there is a product already linked to your account or company, you are able to publish the job immediately yourself via the Dashboard. The Customer Service team will still review the job and confirm it has been published. In some cases the team will make updates to the job before it gets published.
+
+## Submit via Customer Service
+
+You can submit your job posting request by contacting the Customer Service team via [jobs@fashionunited.com](mailto:jobs@fashionunited.com).
+
+### What to include in your email
+
+- **Job description** -- Attached as a Word document (preferred) or a direct link to the job description on your website (not a link to a general career page)
+- **One job per email** -- We post 1 job per function and location
+  - Example: Assistant Store Manager & Store Manager = 2 positions = 2 jobs
+  - Example: Mini job / Trainee = 2 positions = 2 jobs
+- **Job title + location** -- If not clear in the job description
+- **Logo and image** -- If this is your first job posting, we need your [logo and an image](/docs/jobs/job-layout/). Make sure logo and image are sent as separate files (not embedded in a Word document or PDF)
+- **Application method** -- Explain if you want:
+  - An external apply link (if yes, include that link)
+  - An apply button (specify which email address applications should be sent to)
+
+### What happens next
+
+The team will check the CRM system:
+
+1. If this is your first time (or the first time in years), the team will onboard you
+2. If there is a product linked to your account, the team will proceed with publishing accordingly
+3. If you are doing single job postings, the team will proceed with publishing accordingly
+4. In case of questions, the team will be in touch with you
+
+## Automated posting
+
+For automated job posting via feed integration or scraper, see [Integrations Overview](/docs/jobs/integrations-overview/).

--- a/src/content/docs/docs/jobs/outbound-feed/index.md
+++ b/src/content/docs/docs/jobs/outbound-feed/index.md
@@ -1,0 +1,24 @@
+---
+title: Job Feed Outbound
+description: "Receive an XML feed of your FashionUnited jobs to display on your own website."
+---
+
+We can provide you with an XML URL which contains your jobs currently published on FashionUnited. You then need to set up the feed connection on your end and can also make your own mapping rules -- for example, only showing certain positions on your website by filtering on categories, countries, or cities.
+
+## How it works
+
+- Via the Dashboard you are able to manage the jobs (publish, unpublish, repost, and edit)
+- FashionUnited serves as "the source" -- the connection between our job board and your website (we are your ATS)
+- The XML feed updates automatically as you manage your jobs
+
+## Setup
+
+The setup of the feed is something you need to do on your end. We are not able to support you with this on a technical level, since all the work needs to happen on your side.
+
+To get your job XML URL, contact the Customer Service team at [jobs@fashionunited.com](mailto:jobs@fashionunited.com).
+
+## Alternatives
+
+If you prefer not to set up a feed yourself, consider the [Job Embedder](/docs/fashionunited-for-websites/) -- a simpler way to display your FashionUnited jobs on your website by embedding a code snippet.
+
+For a full overview of integration options, see [Integrations Overview](/docs/jobs/integrations-overview/).

--- a/src/content/docs/docs/jobs/premium-employer/employer-branding-page/index.md
+++ b/src/content/docs/docs/jobs/premium-employer/employer-branding-page/index.md
@@ -1,0 +1,35 @@
+---
+title: Employer Branding Page
+description: "A fully customised employer page with brand content, news, and highlighted job listings."
+---
+
+As a Premium Employer, an Employer Branding Page can be part of your package. The Employer Branding Page is a customised company page dedicated to your brand. It contains your own banner image, brand logo, company description, and next to the job overview, one or two tabs with brand content and news.
+
+Additionally, jobs appear with a pink highlight next to them in the job board, and you have an Employer card visible on the overview page and underneath each job.
+
+## Setup
+
+Our team will put together the page for you using the material you provide.
+
+### What you can send us
+
+- **1 header image** -- See [Premium Header Image](/docs/jobs/premium-employer/premium-header/) for specifications
+- **Content for the tabs** -- These can be texts (via email or Word files), images, and video links. You can also point us to existing pages on your site.
+
+### Page tabs
+
+| Tab | Content |
+|-----|---------|
+| **About** | Information about your brand or company (history, values, for example) |
+| **Working at** | What it is like working at your brand or company (perks and benefits, department information, employee testimonials, for example) |
+| **News** | This tab automatically contains (positive) news published on FashionUnited |
+
+### Guidelines
+
+- **Less is more** -- Keep the content simple and see it as a first glimpse candidates have of you as an employer, not as a replacement or copy of your own website
+- **Mobile first** -- The layout of the tabs will be set up mobile first, meaning simple layouts with no custom fonts or customised text and image placement
+- **No external links** -- External links are not supported in the page content
+
+## Contact
+
+To set up or update your Employer Branding Page, contact [jobs@fashionunited.com](mailto:jobs@fashionunited.com).

--- a/src/content/docs/docs/jobs/premium-employer/index.md
+++ b/src/content/docs/docs/jobs/premium-employer/index.md
@@ -1,0 +1,28 @@
+---
+title: Premium Employer
+description: "Overview of FashionUnited's Premium Employer features and products."
+---
+
+The Premium Employer status entails different products that enhance your presence on FashionUnited.
+
+## Premium Employer products
+
+### [Organizational News Membership](/docs/jobs/premium-employer/news-membership/)
+
+Access paywalled executive news articles on FashionUnited using your company email address.
+
+### [Premium Header Image](/docs/jobs/premium-employer/premium-header/)
+
+A custom banner image for your premium employer page, showcasing your brand to potential candidates.
+
+### [Job Template](/docs/jobs/premium-employer/job-template/)
+
+A custom job template with your logo, up to 3 images, and a video to make your job postings stand out.
+
+### [Employer Branding Page](/docs/jobs/premium-employer/employer-branding-page/)
+
+A fully customised company page with your own banner image, brand content tabs (About, Working at, News), highlighted job listings, and an employer card on the job board.
+
+## Getting started
+
+Contact [jobs@fashionunited.com](mailto:jobs@fashionunited.com) to learn more about Premium Employer packages and pricing.

--- a/src/content/docs/docs/jobs/premium-employer/job-template/index.md
+++ b/src/content/docs/docs/jobs/premium-employer/job-template/index.md
@@ -1,0 +1,22 @@
+---
+title: Job Template
+description: "Custom job templates for Premium Employers with images and video."
+---
+
+As a Premium Employer you can receive your own job template to make your job postings stand out.
+
+## What to provide
+
+- **Logo** -- Your logo as SVG (or PNG) file
+- **Images** -- 1 to 3 images (landscape format, 970 px wide, high resolution). All images need to have the same exact dimensions.
+- **Video** -- 1 video link (public video on YouTube or Vimeo)
+
+## Updating your template
+
+Images and video can easily be updated (per season, for example). Share new materials with [jobs@fashionunited.com](mailto:jobs@fashionunited.com) and all active jobs will be updated.
+
+## Related
+
+- [Job Layout](/docs/jobs/job-layout/) -- Standard job layout and image requirements
+- [Logo requirements](/docs/logo/) -- SVG logo specifications
+- [Header Image Requirements](/docs/header/) -- Image dimensions and resolution

--- a/src/content/docs/docs/jobs/premium-employer/news-membership/index.md
+++ b/src/content/docs/docs/jobs/premium-employer/news-membership/index.md
@@ -1,0 +1,21 @@
+---
+title: Organizational News Membership
+description: "Access paywalled FashionUnited news articles with your company email address."
+---
+
+Certain news articles on FashionUnited are only accessible when a visitor of the website has a paid subscription or is linked to a company or brand which has an Organizational News Membership.
+
+## Accessing executive news
+
+When news access is included in your partnership with FashionUnited, you can log in with your company email address to access the paywalled news articles:
+
+- By signing in via the homepage of FashionUnited (upper right corner)
+- By signing in via an executive news article
+
+:::note
+You need to use your **company email address**, since access is linked to email domains.
+:::
+
+## Troubleshooting
+
+If you are not able to access the executive news, contact [jobs@fashionunited.com](mailto:jobs@fashionunited.com).

--- a/src/content/docs/docs/jobs/premium-employer/premium-header/index.md
+++ b/src/content/docs/docs/jobs/premium-employer/premium-header/index.md
@@ -1,0 +1,22 @@
+---
+title: Premium Header Image
+description: "Banner image specifications for your Premium Employer page on FashionUnited."
+---
+
+An Employer Page Premium has its own banner image, brand logo, company description, and job overview.
+
+## Banner image
+
+For the banner (shown on top of the page), think of showing part of your collection or a campaign image which gives potential candidates a good first impression.
+
+### Image requirements
+
+- Dimensions: 2560 x 526 px minimum (bigger is better)
+- Resolution: 72 dpi minimum
+- Higher resolution or bigger image size is always better
+
+For general header image specifications, see [Header Image Requirements](/docs/header/).
+
+## Updating your banner image
+
+To update your premium employer banner image, contact [jobs@fashionunited.com](mailto:jobs@fashionunited.com) with your new image.

--- a/src/content/docs/docs/logo/index.md
+++ b/src/content/docs/docs/logo/index.md
@@ -59,6 +59,8 @@ are therefore best supplied in SVG format.
 TLDR; If you want your brand to look best on the internet, on all devices, use
 SVG.
 
+See also: [Job Layout](/docs/jobs/job-layout/) for logo requirements when posting jobs, and [Employer Page](/docs/jobs/employer-page/) for how your logo appears on your company page.
+
 ## FashionUnited Logo Usage
 
 The logo makes the link between fashion and uniting everyone working within the


### PR DESCRIPTION
## Summary
- Replace `secrets.ANTHROPIC_API_KEY` with `secrets.CLAUDE_CODE_OAUTH_TOKEN` in 1 GitHub workflow file
- Migrates Claude Code GitHub Actions to use OAuth token authentication

## Test plan
- [ ] Verify workflows trigger correctly with the new secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fuww/developer/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
