### PR TITLE
Remove docs prefix from automated workflow PR titles

### DIFF
--- a/.github/workflows/daily-doc-updater.md
+++ b/.github/workflows/daily-doc-updater.md
@@ -30,7 +30,7 @@ timeout-minutes: 30
 safe-outputs:
   create-pull-request:
     expires: 2d
-    title-prefix: "[docs] "
+    title-prefix: ""
     labels: [documentation, automation]
     draft: false
     protected-files: fallback-to-issue
@@ -129,7 +129,7 @@ If you made any documentation changes:
    - Links to relevant merged PRs that triggered the updates
    - Any notes about features that need further review
 
-**PR Title Format**: `[docs] Update documentation for features from [date]`
+**PR Title Format**: `Update documentation for features from [date]`
 
 **PR Description Template**:
 ```markdown

--- a/.github/workflows/glossary-maintainer.md
+++ b/.github/workflows/glossary-maintainer.md
@@ -20,7 +20,7 @@ network:
 safe-outputs:
   create-pull-request:
     expires: 2d
-    title-prefix: "[docs] "
+    title-prefix: ""
     labels: [documentation, glossary]
     draft: false
     protected-files: fallback-to-issue
@@ -190,8 +190,8 @@ If you made any changes to the glossary:
 **Use safe-outputs create-pull-request** to create a PR with:
 
 **PR Title Format**:
-- Daily: `[docs] Update glossary - daily scan`
-- Weekly: `[docs] Update glossary - weekly full scan`
+- Daily: `Update glossary - daily scan`
+- Weekly: `Update glossary - weekly full scan`
 
 **PR Description Template**:
 ````markdown


### PR DESCRIPTION
Remove [docs] title-prefix from agentic workflows to comply with commit/PR title rules. Related to fuww/frontend#3138